### PR TITLE
Update experience references to 6+ years

### DIFF
--- a/ResumeWebsite/App.tsx
+++ b/ResumeWebsite/App.tsx
@@ -105,7 +105,7 @@ const App: React.FC = () => {
                   </div>
                 </div>
                 <div className="grid gap-3 sm:grid-cols-2">
-                  {[{ label: 'Years of building', value: '5+', detail: 'Full stack delivery across web, CMS, and cloud.' }, { label: 'Tech mastered', value: '20+', detail: 'Languages, frameworks, and delivery tooling.' }, { label: 'Deployments shipped', value: '50+', detail: 'Customer-facing launches with zero downtime.' }, { label: 'Collaboration score', value: 'A+', detail: 'Trusted partner to design, product, and ops.' }].map((stat) => (
+                  {[{ label: 'Years of building', value: '6+', detail: 'Full stack delivery across web, CMS, and cloud.' }, { label: 'Tech mastered', value: '20+', detail: 'Languages, frameworks, and delivery tooling.' }, { label: 'Deployments shipped', value: '50+', detail: 'Customer-facing launches with zero downtime.' }, { label: 'Collaboration score', value: 'A+', detail: 'Trusted partner to design, product, and ops.' }].map((stat) => (
                     <div key={stat.label} className="rounded-2xl border border-slate-200/80 bg-white/90 p-4 shadow-lg shadow-cyan-900/10 dark:border-slate-800/80 dark:bg-slate-900/70">
                       <p className="text-xs uppercase tracking-[0.2em] text-cyan-700 dark:text-cyan-300">{stat.label}</p>
                       <p className="text-3xl font-black text-slate-900 dark:text-white">{stat.value}</p>

--- a/ResumeWebsite/constants.ts
+++ b/ResumeWebsite/constants.ts
@@ -9,7 +9,7 @@ export const RESUME_DATA: ResumeData = {
     linkedinHandle: "knalladimmu",
     githubHandle: "ikalyancode",
   },
-  summary: "Software Engineer with 5+ years of experience in Full Stack development, building scalable and high-performance applications across frontend, backend, and CMS platforms. Proven ability to learn and adapt to new technologies, delivering efficient solutions across diverse tech stacks. Skilled in optimizing databases, integrating APIs, and leveraging cloud-native tools to enhance system performance. Experienced in automation, CI/CD pipelines, and system monitoring, ensuring seamless deployments and reliability. Passionate about problem-solving and innovation, creating impactful digital experiences.",
+  summary: "Software Engineer with 6+ years of experience in Full Stack development, building scalable and high-performance applications across frontend, backend, and CMS platforms. Proven ability to learn and adapt to new technologies, delivering efficient solutions across diverse tech stacks. Skilled in optimizing databases, integrating APIs, and leveraging cloud-native tools to enhance system performance. Experienced in automation, CI/CD pipelines, and system monitoring, ensuring seamless deployments and reliability. Passionate about problem-solving and innovation, creating impactful digital experiences.",
   skills: [
     { category: "Languages & Frameworks", skills: ["Java", "JavaScript", "Python", ".Net", "Ruby", "Vue.js", "React.js", "Spring Boot", "AEM"] },
     { category: "Databases & APIs", skills: ["SQL", "PostgreSQL", "MongoDB", "GraphQL", "REST APIs", "AEM JCR", "Sling Models"] },


### PR DESCRIPTION
### Motivation
- Bump all occurrences of "5+ years" to "6+ years" so the resume website accurately reflects the updated experience level.

### Description
- Updated the resume summary and homepage stats to show `6+` years of experience by modifying `ResumeWebsite/constants.ts` and `ResumeWebsite/App.tsx`.

### Testing
- Ran `npm install` and started the dev server with `npm run dev`, then used Playwright to load the homepage and capture `artifacts/resume-website-6plus.png`, and all steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697796f0041c8327a0a09c1bad59d2f4)